### PR TITLE
drawing diagonal correctly

### DIFF
--- a/python/smsPlotABS.py
+++ b/python/smsPlotABS.py
@@ -234,7 +234,7 @@ class smsPlotABS(object):
         self.c.LExpP = LExpP
 
     def DrawDiagonal(self):
-        diagonal = rt.TGraph(3, self.model.diagX, self.model.diagY)
+        diagonal = rt.TGraph(2, array('d',[self.model.Xmin,self.model.Xmax]), array('d',[self.model.Xmin,self.model.Xmax]))
         diagonal.SetName("diagonal")
         diagonal.SetFillColor(rt.kWhite)
         diagonal.SetLineColor(rt.kGray)


### PR DESCRIPTION
If sms.model.diagOn is set to True, the program crashes, since it's not able to find diagX or diagY.
With the fix provided in this pr, the diagonal is drawn correctly if xmin>ymin and xmax>=ymax, which is correct for most of our sms scans.
