### PR TITLE
use all space-separated values as attribute

### DIFF
--- a/python/inputFile.py
+++ b/python/inputFile.py
@@ -18,7 +18,7 @@ class inputFile():
             tmpLINE =  line[:-1].split(" ")
             if tmpLINE[0] != attribute: continue
             fileIN.close()
-            return tmpLINE[1]
+            return " ".join(tmpLINE[1:])
 
     def findHISTOGRAM(self, fileName):
         fileIN = open(fileName)        


### PR DESCRIPTION
Use everything following the attribute keyword as the value.
This allows things like

```
PRELIMINARY private work
```

which at the moment would be read as

```
PRELIMINARY private
```
